### PR TITLE
Remove node-specific things

### DIFF
--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -2,7 +2,7 @@ import GeoTIFFImage from './geotiffimage';
 import DataView64 from './dataview64';
 import DataSlice from './dataslice';
 import Pool from './pool';
-import { makeRemoteSource, makeBufferSource, makeFileSource, makeFileReaderSource } from './source';
+import { makeRemoteSource, makeBufferSource, makeFileReaderSource } from './source';
 import { fieldTypes, fieldTagNames, arrayFields, geoKeyNames } from './globals';
 import { writeGeotiff } from './geotiffwriter';
 import * as globals from './globals';
@@ -662,20 +662,6 @@ export async function fromUrl(url, options = {}) {
  */
 export async function fromArrayBuffer(arrayBuffer) {
   return GeoTIFF.fromSource(makeBufferSource(arrayBuffer));
-}
-
-/**
- * Construct a GeoTIFF from a local file path. This uses the node
- * [filesystem API]{@link https://nodejs.org/api/fs.html} and is
- * not available on browsers.
- *
- * N.B. After the GeoTIFF has been completely processed it needs
- * to be closed but only if it has been constructed from a file.
- * @param {string} path The file path to read from.
- * @returns {Promise.<GeoTIFF>} The resulting GeoTIFF file.
- */
-export async function fromFile(path) {
-  return GeoTIFF.fromSource(makeFileSource(path));
 }
 
 /**

--- a/src/source.js
+++ b/src/source.js
@@ -1,9 +1,3 @@
-import { Buffer } from 'buffer';
-import { open, read, close } from 'fs';
-import http from 'http';
-import https from 'https';
-import urlMod from 'url';
-
 
 function readRangeFromBlocks(blocks, rangeOffset, rangeLength) {
   const rangeTop = rangeOffset + rangeLength;
@@ -317,43 +311,6 @@ export function makeXHRSource(url, { headers = {}, blockSize } = {}) {
 }
 
 /**
- * Create a new source to read from a remote file using the node
- * [http]{@link https://nodejs.org/api/http.html} API.
- * @param {string} url The URL to send requests to.
- * @param {Object} [options] Additional options.
- * @param {Number} [options.blockSize] The block size to use.
- * @param {object} [options.headers] Additional headers to be sent to the server.
- */
-export function makeHttpSource(url, { headers = {}, blockSize } = {}) {
-  return new BlockedSource(async (offset, length) => new Promise((resolve, reject) => {
-    const parsed = urlMod.parse(url);
-    const request = (parsed.protocol === 'http:' ? http : https).get(
-      { ...parsed,
-        headers: {
-          ...headers, Range: `bytes=${offset}-${offset + length - 1}`,
-        } }, (result) => {
-        const chunks = [];
-        // collect chunks
-        result.on('data', (chunk) => {
-          chunks.push(chunk);
-        });
-
-        // concatenate all chunks and resolve the promise with the resulting buffer
-        result.on('end', () => {
-          const data = Buffer.concat(chunks).buffer;
-          resolve({
-            data,
-            offset,
-            length: data.byteLength,
-          });
-        });
-      },
-    );
-    request.on('error', reject);
-  }), { blockSize });
-}
-
-/**
  * Create a new source to read from a remote file. Uses either XHR, fetch or nodes http API.
  * @param {string} url The URL to send requests to.
  * @param {Object} [options] Additional options.
@@ -370,9 +327,6 @@ export function makeRemoteSource(url, options) {
   if (typeof XMLHttpRequest !== 'undefined') {
     return makeXHRSource(url, options);
   }
-  if (http.get) {
-    return makeHttpSource(url, options);
-  }
   throw new Error('No remote source available');
 }
 
@@ -386,63 +340,6 @@ export function makeBufferSource(arrayBuffer) {
   return {
     async fetch(offset, length) {
       return arrayBuffer.slice(offset, offset + length);
-    },
-  };
-}
-
-function closeAsync(fd) {
-  return new Promise((resolve, reject) => {
-    close(fd, err => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve()
-      }
-    });
-  });
-}
-
-function openAsync(path, flags, mode = undefined) {
-  return new Promise((resolve, reject) => {
-    open(path, flags, mode, (err, fd) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(fd);
-      }
-    });
-  });
-}
-
-function readAsync(...args) {
-  return new Promise((resolve, reject) => {
-    read(...args, (err, bytesRead, buffer) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve({ bytesRead, buffer });
-      }
-    });
-  });
-}
-
-/**
- * Creates a new source using the node filesystem API.
- * @param {string} path The path to the file in the local filesystem.
- * @returns The constructed source
- */
-export function makeFileSource(path) {
-  const fileOpen = openAsync(path, 'r');
-
-  return {
-    async fetch(offset, length) {
-      const fd = await fileOpen;
-      const { buffer } = await readAsync(fd, Buffer.alloc(length), 0, length, offset);
-      return buffer.buffer;
-    },
-    async close() {
-      const fd = await fileOpen;
-      return await closeAsync(fd);
     },
   };
 }


### PR DESCRIPTION
I was able to get rollup to build Vitessce by making some changes here to remove the node imports.

Before this, I tried for a while to use https://github.com/calvinmetcalf/rollup-plugin-node-builtins but could not figure out how to provide the "empty" imports (which I believe is what webpack does)